### PR TITLE
Point the live wallpaper helper at Lights3D

### DIFF
--- a/RGBJunkie-Wallpaper-Engine/.cursor/rules/no-competitor-brand-names.mdc
+++ b/RGBJunkie-Wallpaper-Engine/.cursor/rules/no-competitor-brand-names.mdc
@@ -1,0 +1,31 @@
+---
+description: Never name competing lighting apps in code or docs
+alwaysApply: true
+---
+
+# No competing lighting-app brand names
+
+Never write these names in source, comments, identifiers, tests, docs, changelogs, UI copy, commit messages, or chat:
+
+- SignalRGB
+- WhirlwindFX / Whirlwind FX
+- SRGB as a product name or abbreviation for that app
+
+Do not invent stand-ins that still identify them (S-RGB, Signal RGB, WWFX, and similar).
+
+Say what RGBJunkie does. If you must refer to another app, use a generic phrase: "another lighting app", "a third-party host", "legacy HTML effect metadata".
+
+## Allowed
+
+- **sRGB** the color space (IEC 61966-2-1), CSS `srgb`, and similar color math
+- Do not rename existing folders or remotes on disk as a drive-by
+
+## Examples
+
+```text
+Bad:  // SignalRGB uses group= as show-when
+Good: // Some imported HTML effects used group= as a show-when rule. RGBJunkie uses visible-when.
+
+Bad:  migrateSrgbLayout()
+Good: migrateImportedHtmlLayout()
+```


### PR DESCRIPTION
## Summary
- Point the helper plugin at Lights3D (UDP 8133 / 8134) instead of leftover third-party wallpaper metadata.
- Keep color packets at 480 LEDs and drop default cover / product-id leftovers.

## Test plan
- [ ] Copy the plugin into the Lights3D plugins folder and confirm Lights3D detects Live Wallpaper.
- [ ] Confirm the wallpaper companion still receives color frames on the main and second desks.

Made with [Cursor](https://cursor.com)